### PR TITLE
FEATURE: `requiredFields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 
 See this thread for tweet-sized introduction:
 
-
-
 [<img src="https://user-images.githubusercontent.com/837032/139540771-8e84d6d2-0c43-4673-a9f7-9e335d47c8a7.png" width="450"/>](https://twitter.com/dimaip/status/1454480140872949761)
-
 
 ## Theory
 
@@ -54,6 +51,7 @@ Note how roles may accept arbitrary arguments that would be passed to the role m
 const config = {
   globalRoles: {
     Owner: {
+      requiredFields: (roleArgs) => ({ [roleArgs.userField]: true }),
       matcher: (ctx, record, roleArgs) => ctx.currentUser?.id === record?.[roleArgs.userField],
       queryConstraint: (ctx, roleArgs) => ({
         [roleArgs.userField]: ctx.currentUser?.id,
@@ -63,6 +61,7 @@ const config = {
   rolesPerType: {
     Purchases: {
       Owner: {
+        requiredFields: (roleArgs) => ({ id: true, [roleArgs.userField]: true }),
         matcher: (ctx, record, roleArgs) => someCondition(ctx) && ctx.currentUser?.id === record?.[roleArgs.userField],
         queryConstraint: (ctx, roleArgs) =>
           someCondition(ctx) && {
@@ -76,6 +75,7 @@ const config = {
 
 `matcher` is used to restrict access to individual records. It should return `boolean`.
 `queryConstraint` is used to generate a `where` clause for Prisma which should be used to restrict list fields and list relations.
+`roleArgs` is used to declare the data requirements needed for the above validators to work (i.e. everything you want to be inside `record.*` must be listed there). It can be either an object in Prisma's `select` argument format or a function that takes role arguments and returns that object.
 
 3. Apply `context.withAuth` to every Prisma call like this:
 

--- a/src/getRequiredFields.test.ts
+++ b/src/getRequiredFields.test.ts
@@ -1,0 +1,56 @@
+import { RolesPerType, Role } from '.'
+import { getRequiredFields } from './getRequiredFields'
+
+interface Context {
+  currentUser: {
+    id: string
+    isAdmin?: boolean
+  }
+  withAuth: <T extends unknown>(query: T) => T
+}
+interface Purchase {
+  id: string
+  User: {
+    id: string
+  }
+}
+
+const userContext: Context = {
+  currentUser: {
+    id: 'myUserId',
+  },
+  withAuth: (t) => t,
+}
+
+test('getRequiredFields', async () => {
+  const rolesPerType: RolesPerType<Context, Purchase> = {
+    User: {
+      Owner: {
+        matcher: (ctx, record) => ctx.currentUser?.id === record?.id,
+        queryConstraint: (ctx) => ({
+          id: ctx.currentUser?.id,
+        }),
+        requiredFields: (args: any) => ({ [args.testArg]: true }),
+      },
+      Nobody: {
+        matcher: () => false,
+        queryConstraint: () => false,
+      },
+    },
+  }
+  const globalRoles: { [role: string]: Role<Context, any, any> } = {
+    Admin: {
+      matcher: (ctx) => ctx.currentUser?.isAdmin === true,
+      queryConstraint: (ctx) => ctx.currentUser?.isAdmin === true,
+      requiredFields: { globalTestField: true },
+    },
+  }
+  const config = { globalRoles, rolesPerType }
+
+  expect(
+    await getRequiredFields('User', '@Auth(read:[Admin,Owner(testArg:testFieldFromArgs)])', config, userContext)
+  ).toEqual({
+    globalTestField: true,
+    testFieldFromArgs: true,
+  })
+})

--- a/src/getRequiredFields.ts
+++ b/src/getRequiredFields.ts
@@ -1,0 +1,33 @@
+import { Configuration, Context, RolesPerType } from '.'
+import { descriptionToRoles } from './descriptionToRoles'
+import { PrismaSelect } from './select'
+
+/**
+ * Get all the fields that are declared by the Role as required.
+ * Rule.requiredFields takes either a `select` object or a function that takes role arguments and returns a `select` object.
+ */
+export const getRequiredFields = (
+  fieldType: string,
+  description: string,
+  config: Configuration | undefined,
+  context: Context
+) => {
+  const rolesPerType = config?.rolesPerType
+  const globalRoles = config?.globalRoles
+
+  const readRoles = descriptionToRoles(description)?.read || []
+  if (readRoles.length === 0) {
+    return null
+  }
+  return readRoles.reduce((acc, role) => {
+    const requiredFields =
+      rolesPerType?.[fieldType as keyof RolesPerType]?.[role.name]?.requiredFields ||
+      globalRoles?.[role.name]?.requiredFields
+    if (typeof requiredFields === 'function') {
+      PrismaSelect.mergeDeep(acc, requiredFields(role.args))
+    } else if (typeof requiredFields === 'object') {
+      PrismaSelect.mergeDeep(acc, requiredFields)
+    }
+    return acc
+  }, {})
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { RoleArgs } from './descriptionToRoles'
 export interface Role<C, R, W> {
   matcher: (context: C, record: R, roleArgs: RoleArgs) => boolean
   queryConstraint: (context: C, roleArgs: RoleArgs) => W | boolean
+  requiredFields?: Record<string, any> | ((roleArgs: RoleArgs) => Record<string, any>)
 }
 
 export interface RolesPerType<C = any, R = any, W = any> {


### PR DESCRIPTION
Introduce a new Role's property: `roleArgs`. It is used to declare the data requirements needed for the above validators to work (i.e. everything you want to be inside `record.*` must be listed there). It can be either an object in Prisma's `select` argument format or a function that takes role arguments and returns that object.

```js
{
  globalRoles: {
    Owner: {
      requiredFields: (roleArgs) => ({ [roleArgs.userField]: true }),
      matcher: (ctx, record, roleArgs) => ctx.currentUser?.id === record?.[roleArgs.userField],
      queryConstraint: (ctx, roleArgs) => ({
        [roleArgs.userField]: ctx.currentUser?.id,
      }),
    },
  }
}
```