### PR TITLE
BUG: clone context instead of mutating when setting `withAuth`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joindeed/prisma-auth",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Declarative Prisma Authorization layer",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
We were mutating `context`, and since it's shared between multiple resolvers in parallel, we were getting weird bugs due to wrong `info` being passed to `withAuth`.