### PR TITLE
BUG: don't fail on empty where constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joindeed/prisma-auth",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Declarative Prisma Authorization layer",
   "main": "dist/index.js",
   "scripts": {

--- a/src/makeListConstraintMiddleware.ts
+++ b/src/makeListConstraintMiddleware.ts
@@ -44,7 +44,7 @@ export const makeListConstraintMiddleware: (config: Configuration) => Middleware
           options,
           context
         )
-        selectValue = { where }
+        selectValue = where ? { where } : {}
       // Get the value for the root return type of the resolver
       } else {
         selectValue = select.value


### PR DESCRIPTION
When there are no constraints on a type, `prisma-auth` would fail.