### PR TITLE
BUG: prevent user's OR query from clashing with auth

### DIFF
--- a/src/getListWhereConstrains.test.ts
+++ b/src/getListWhereConstrains.test.ts
@@ -67,24 +67,36 @@ test('makeListConstraintMiddleware', async () => {
   const config = { globalRoles, rolesPerType }
 
   expect(await getListWhereConstrains('User', '@Auth(read:[Admin,Owner])', config, userContext)).toEqual({
-    OR: [
+    AND: [
       {
-        id: 'myUserId',
+        OR: [
+          {
+            id: 'myUserId',
+          },
+        ],
       },
     ],
   })
   expect(await getListWhereConstrains('User', '@Auth(read:[Admin,Owner])', config, adminContext)).toEqual({
-    OR: [
-      alwaysTrueCondition,
+    AND: [
       {
-        id: 'myUserId',
+        OR: [
+          alwaysTrueCondition,
+          {
+            id: 'myUserId',
+          },
+        ],
       },
     ],
   })
   expect(await getListWhereConstrains('User', '@Auth(read:[Admin,Owner])', config, strangerContext)).toEqual({
-    OR: [
+    AND: [
       {
-        id: 'strangerUserId',
+        OR: [
+          {
+            id: 'strangerUserId',
+          },
+        ],
       },
     ],
   })


### PR DESCRIPTION
Currently prisma-auth works like this:

```js
const authCondition = {
  OR: [{ communityId: <communityId>}]
}
const userQuery = {
  OR: [{ some: <thing>}]
}
const mergedQuery = {
  OR: [{ communityId: <communityId>}, { some: <thing>}]
}
```
which obviously breaks both the auth and the query.

The new logic is this:

```js
const authCondition = {
  AND: [{
    OR: [{ communityId: <communityId>}]
  }]
}
const userQuery = {
  OR: [{ some: <thing>}]
}
const mergedQuery = {
  AND: [{
    OR: [{ communityId: <communityId>}]
  }],
  OR: [{ some: <thing>}]
}
```
Which enforces both the user's condition AND the auth query.
