### PR TITLE
BUG: don't treat dates as objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joindeed/prisma-auth",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Declarative Prisma Authorization layer",
   "main": "dist/index.js",
   "scripts": {

--- a/src/select.ts
+++ b/src/select.ts
@@ -114,7 +114,12 @@ export class PrismaSelect {
   }
 
   static isObject(item: any) {
-    return item && typeof item === 'object' && !Array.isArray(item) && typeof item?.toISOString !== 'function'
+    return (
+      item &&
+      typeof item === 'object' &&
+      !Array.isArray(item) &&
+      Object.prototype.toString.call(item) !== '[object Date]'
+    )
   }
 
   static mergeDeep(target: any, ...sources: any[]): any {

--- a/src/select.ts
+++ b/src/select.ts
@@ -114,7 +114,7 @@ export class PrismaSelect {
   }
 
   static isObject(item: any) {
-    return item && typeof item === 'object' && !Array.isArray(item)
+    return item && typeof item === 'object' && !Array.isArray(item) && typeof item?.toISOString !== 'function'
   }
 
   static mergeDeep(target: any, ...sources: any[]): any {


### PR DESCRIPTION
**Steps to reproduce**

```js
context.withAuth({
      create: { createdAt: new Date() },
      ...
    })
```
This code used to yield: `{create: {createdAt: {}}}`