### PR TITLE
BUG: fix `getListWhereConstrains` when no roles match

### DIFF
--- a/src/getListWhereConstrains.test.ts
+++ b/src/getListWhereConstrains.test.ts
@@ -100,4 +100,13 @@ test('makeListConstraintMiddleware', async () => {
       },
     ],
   })
+  expect(await getListWhereConstrains('User', '@Auth(read:[Admin,Nobody])', config, strangerContext)).toEqual({
+    AND: [
+      {
+        id: {
+          equals: 'ffffffffffffffffffffffff',
+        }
+      },
+    ],
+  })
 })

--- a/src/getListWhereConstrains.ts
+++ b/src/getListWhereConstrains.ts
@@ -13,6 +13,15 @@ export const alwaysTrueCondition = {
 }
 
 /**
+ * We need some kind of Prisma condition that would be always FALSE. This is the best I could think of...
+ */
+export const alwaysFalseCondition = {
+  id: {
+    equals: 'ffffffffffffffffffffffff',
+  },
+}
+
+/**
  * Generate a Prisma `where` clause for filtering list queries and list relations
  */
 export const getListWhereConstrains = (
@@ -28,29 +37,35 @@ export const getListWhereConstrains = (
   if (readRoles.length === 0) {
     return null
   }
+
+  const effectiveConstraints = readRoles
+    .map((role) => {
+      const queryConstraint =
+        rolesPerType?.[fieldType as keyof RolesPerType]?.[role.name]?.queryConstraint ||
+        globalRoles?.[role.name]?.queryConstraint
+      if (!queryConstraint) {
+        throw new Error(`Query constraint for role "${role.name}" in model "${fieldType}" not found`)
+      }
+      const result = queryConstraint(context, role.args)
+      if (typeof result === 'object') {
+        return result
+      }
+      if (result === true) {
+        return alwaysTrueCondition
+      }
+      return null
+    })
+    .filter(Boolean)
   return {
     // We wrap the enforced query into AND to make sure it doesn't clash with the user's OR query
     AND: [
-      {
-        OR: readRoles
-          .map((role) => {
-            const queryConstraint =
-              rolesPerType?.[fieldType as keyof RolesPerType]?.[role.name]?.queryConstraint ||
-              globalRoles?.[role.name]?.queryConstraint
-            if (!queryConstraint) {
-              throw new Error(`Query constraint for role "${role.name}" in model "${fieldType}" not found`)
-            }
-            const result = queryConstraint(context, role.args)
-            if (typeof result === 'object') {
-              return result
-            }
-            if (result === true) {
-              return alwaysTrueCondition
-            }
-            return null
-          })
-          .filter(Boolean),
-      },
+      effectiveConstraints.length > 0
+        ? {
+            OR: effectiveConstraints,
+          }
+        :
+        // If none of the roles have a query constraint, we must short-circuit the query and return an always-false condition
+        alwaysFalseCondition,
     ],
   }
 }


### PR DESCRIPTION
When no roles match, the list constraint ends up looking like this, thus effectively returning all records:

```
{
  AND: [{
    OR: []
  }]
}
```

Instead of returning an empty array we should be returning a condition that would always evaluate to false.

## TODO:
- [x] tests